### PR TITLE
feat(nvim-minimal): add lean Neovim config with minimal plugins

### DIFF
--- a/nvim-minimal/init.lua
+++ b/nvim-minimal/init.lua
@@ -1,0 +1,3 @@
+require("options")
+require("plugins")
+require("lsp")

--- a/nvim-minimal/init.lua
+++ b/nvim-minimal/init.lua
@@ -1,5 +1,5 @@
 if vim.fn.has("nvim-0.12") == 0 then
-    error("nvim-minimal requires Neovim 0.12+ (vim.pack, vim.lsp.config)")
+    error("nvim-minimal requires Neovim 0.12+ (vim.pack)")
 end
 
 require("options")

--- a/nvim-minimal/init.lua
+++ b/nvim-minimal/init.lua
@@ -1,3 +1,7 @@
+if vim.fn.has("nvim-0.12") == 0 then
+    error("nvim-minimal requires Neovim 0.12+ (vim.pack, vim.lsp.config)")
+end
+
 require("options")
 require("plugins")
 require("lsp")

--- a/nvim-minimal/lua/lsp.lua
+++ b/nvim-minimal/lua/lsp.lua
@@ -1,0 +1,59 @@
+vim.diagnostic.config({
+    virtual_text = true,
+    signs = true,
+    underline = true,
+    update_in_insert = false,
+})
+
+-- Filetype detection for Go templates so gopls attaches
+vim.filetype.add({
+    extension = { tmpl = "gotmpl", gotmpl = "gotmpl" },
+})
+
+-- Language servers (install via: brew install gopls pyright)
+vim.lsp.config("gopls", {
+    cmd = { "gopls" },
+    filetypes = { "go", "gomod", "gowork", "gotmpl" },
+    root_markers = { "go.mod", "go.work", ".git" },
+    settings = {
+        gopls = {
+            usePlaceholders = true,
+        },
+    },
+})
+
+vim.lsp.config("pyright", {
+    cmd = { "pyright-langserver", "--stdio" },
+    filetypes = { "python" },
+    root_markers = { "pyproject.toml", "setup.py", "setup.cfg", "requirements.txt", "Pipfile", ".git" },
+})
+
+vim.lsp.enable({ "gopls", "pyright" })
+
+vim.api.nvim_create_autocmd("LspAttach", {
+    group = vim.api.nvim_create_augroup("UserLspConfig", {}),
+    callback = function(ev)
+        local function opts(desc) return { buffer = ev.buf, desc = desc } end
+        local client = vim.lsp.get_client_by_id(ev.data.client_id)
+
+        -- Native insert-mode completion (Neovim 0.11+)
+        if client and client:supports_method("textDocument/completion") then
+            vim.lsp.completion.enable(true, client.id, ev.buf, { autotrigger = true })
+        end
+
+        vim.keymap.set("n", "gd", vim.lsp.buf.definition, opts("Go to Definition"))
+        vim.keymap.set("n", "gi", vim.lsp.buf.implementation, opts("Go to Implementation"))
+        vim.keymap.set("n", "gr", vim.lsp.buf.references, opts("Go to References"))
+        vim.keymap.set("n", "K", vim.lsp.buf.hover, opts("Hover Info"))
+        vim.keymap.set({ "n", "i" }, "<C-k>", vim.lsp.buf.signature_help, opts("Signature Help"))
+        vim.keymap.set("n", "<leader>rn", vim.lsp.buf.rename, opts("Rename Symbol"))
+        vim.keymap.set("n", "<leader>ca", vim.lsp.buf.code_action, opts("Code Action"))
+
+        local fzf = require("fzf-lua")
+        vim.keymap.set("n", "<leader>li", fzf.lsp_implementations, opts("Implementations"))
+        vim.keymap.set("n", "<leader>lr", fzf.lsp_references, opts("References"))
+        vim.keymap.set("n", "<leader>ls", fzf.lsp_document_symbols, opts("Document Symbols"))
+        vim.keymap.set("n", "<leader>ld", fzf.lsp_definitions, opts("Definitions"))
+        vim.keymap.set("n", "<leader>lt", fzf.lsp_typedefs, opts("Type Definitions"))
+    end,
+})

--- a/nvim-minimal/lua/lsp.lua
+++ b/nvim-minimal/lua/lsp.lua
@@ -42,12 +42,7 @@ vim.api.nvim_create_autocmd("LspAttach", {
         end
 
         vim.keymap.set("n", "gd", vim.lsp.buf.definition, opts("Go to Definition"))
-        vim.keymap.set("n", "gi", vim.lsp.buf.implementation, opts("Go to Implementation"))
-        vim.keymap.set("n", "gr", vim.lsp.buf.references, opts("Go to References"))
-        vim.keymap.set("n", "K", vim.lsp.buf.hover, opts("Hover Info"))
-        vim.keymap.set({ "n", "i" }, "<C-k>", vim.lsp.buf.signature_help, opts("Signature Help"))
-        vim.keymap.set("n", "<leader>rn", vim.lsp.buf.rename, opts("Rename Symbol"))
-        vim.keymap.set("n", "<leader>ca", vim.lsp.buf.code_action, opts("Code Action"))
+        vim.keymap.set("n", "<C-k>", vim.lsp.buf.signature_help, opts("Signature Help"))
 
         local fzf = require("fzf-lua")
         vim.keymap.set("n", "<leader>li", fzf.lsp_implementations, opts("Implementations"))

--- a/nvim-minimal/lua/options.lua
+++ b/nvim-minimal/lua/options.lua
@@ -17,7 +17,7 @@ vim.opt.splitbelow = true
 -- Write buffer
 vim.keymap.set('n', '<leader>w', ':write<CR>', { desc = 'Write buffer' })
 vim.keymap.set('n', '<leader>q', ':quit<CR>', { desc = 'Quit window' })
-vim.keymap.set('n', '<leader>wq', ':wq<CR>', { desc = 'Write and quit' })
+vim.keymap.set('n', '<leader>x', ':wq<CR>', { desc = 'Write and quit' })
 
 -- Tab navigation
 vim.keymap.set('n', '<leader>tn', ':tabnext<CR>', { desc = 'Next tab' })

--- a/nvim-minimal/lua/options.lua
+++ b/nvim-minimal/lua/options.lua
@@ -59,7 +59,8 @@ vim.opt.foldlevelstart = 99
 vim.opt.autoread = true
 vim.opt.updatetime = 100
 
--- macOS specific
+-- Keep Neovim's yank register separate from the system clipboard;
+-- use "+y / "+p explicitly when crossing the boundary.
 vim.opt.clipboard = ""
 
 -- Improved backups and undo

--- a/nvim-minimal/lua/options.lua
+++ b/nvim-minimal/lua/options.lua
@@ -1,0 +1,101 @@
+-- Leader key settings
+vim.g.mapleader = " "
+vim.g.maplocalleader = "\\"
+
+-- UI and display
+vim.opt.termguicolors = true
+vim.opt.number = true
+vim.opt.relativenumber = true
+vim.opt.signcolumn = "yes"
+vim.opt.cursorline = true
+vim.opt.scrolloff = 5
+vim.opt.sidescrolloff = 5
+vim.opt.laststatus = 3
+vim.opt.splitright = true
+vim.opt.splitbelow = true
+
+-- Write buffer
+vim.keymap.set('n', '<leader>w', ':write<CR>', { desc = 'Write buffer' })
+vim.keymap.set('n', '<leader>q', ':quit<CR>', { desc = 'Quit window' })
+vim.keymap.set('n', '<leader>wq', ':wq<CR>', { desc = 'Write and quit' })
+
+-- Tab navigation
+vim.keymap.set('n', '<leader>tn', ':tabnext<CR>', { desc = 'Next tab' })
+vim.keymap.set('n', '<leader>tp', ':tabprevious<CR>', { desc = 'Previous tab' })
+vim.keymap.set('n', '<leader>tc', ':tabnew<CR>', { desc = 'Create tab' })
+vim.keymap.set('n', '<leader>tx', ':tabclose<CR>', { desc = 'Close tab' })
+
+-- New keymaps for tab positions
+vim.keymap.set('n', '<leader>t1', '1gt', { desc = 'Go to tab 1' })
+vim.keymap.set('n', '<leader>t2', '2gt', { desc = 'Go to tab 2' })
+vim.keymap.set('n', '<leader>t3', '3gt', { desc = 'Go to tab 3' })
+vim.keymap.set('n', '<leader>t4', '4gt', { desc = 'Go to tab 4' })
+vim.keymap.set('n', '<leader>t5', '5gt', { desc = 'Go to tab 5' })
+vim.keymap.set('n', '<leader>t0', ':tablast<CR>', { desc = 'Go to last tab' })
+
+-- Search behavior
+vim.opt.ignorecase = true
+vim.opt.smartcase = true
+
+-- Indentation and formatting
+vim.opt.expandtab = true
+vim.opt.tabstop = 4
+vim.opt.shiftwidth = 4
+vim.opt.smartindent = true
+vim.opt.wrap = false
+
+-- Modern file handling
+vim.opt.fileformats = "unix,dos"
+
+-- Folding
+vim.opt.foldmethod = "indent"
+vim.opt.foldlevel = 99
+vim.opt.foldlevelstart = 99
+
+-- Better buffer handling
+vim.opt.autoread = true
+vim.opt.updatetime = 100
+
+-- macOS specific
+vim.opt.clipboard = ""
+
+-- Improved backups and undo
+vim.opt.backup = false
+vim.opt.writebackup = false
+vim.opt.swapfile = false
+vim.opt.undofile = true
+
+-- Auto-reload files changed outside Neovim (for Claude Code workflow)
+local reload_interval = 1000
+
+local function check_visible_buffers()
+    if vim.fn.mode() ~= "n" then return end
+
+    local seen = {}
+
+    for _, win in ipairs(vim.api.nvim_list_wins()) do
+        local buf = vim.api.nvim_win_get_buf(win)
+
+        if not seen[buf] then
+            seen[buf] = true
+
+            if vim.bo[buf].buftype == "" then
+                vim.api.nvim_buf_call(buf, function()
+                    vim.cmd("checktime")
+                end)
+            end
+        end
+    end
+end
+
+vim.fn.timer_start(reload_interval, check_visible_buffers, { ["repeat"] = -1 })
+
+vim.api.nvim_create_autocmd({ "FocusGained", "BufEnter" }, {
+    callback = check_visible_buffers,
+})
+
+vim.api.nvim_create_autocmd("FileChangedShellPost", {
+    callback = function(args)
+        vim.notify("Reloaded: " .. vim.fn.fnamemodify(args.file, ":t"), vim.log.levels.INFO)
+    end,
+})

--- a/nvim-minimal/lua/options.lua
+++ b/nvim-minimal/lua/options.lua
@@ -15,23 +15,23 @@ vim.opt.splitright = true
 vim.opt.splitbelow = true
 
 -- Write buffer
-vim.keymap.set('n', '<leader>w', ':write<CR>', { desc = 'Write buffer' })
-vim.keymap.set('n', '<leader>q', ':quit<CR>', { desc = 'Quit window' })
-vim.keymap.set('n', '<leader>x', ':wq<CR>', { desc = 'Write and quit' })
+vim.keymap.set("n", "<leader>w", ":write<CR>", { desc = "Write buffer" })
+vim.keymap.set("n", "<leader>q", ":quit<CR>", { desc = "Quit window" })
+vim.keymap.set("n", "<leader>x", ":wq<CR>", { desc = "Write and quit" })
 
 -- Tab navigation
-vim.keymap.set('n', '<leader>tn', ':tabnext<CR>', { desc = 'Next tab' })
-vim.keymap.set('n', '<leader>tp', ':tabprevious<CR>', { desc = 'Previous tab' })
-vim.keymap.set('n', '<leader>tc', ':tabnew<CR>', { desc = 'Create tab' })
-vim.keymap.set('n', '<leader>tx', ':tabclose<CR>', { desc = 'Close tab' })
+vim.keymap.set("n", "<leader>tn", ":tabnext<CR>", { desc = "Next tab" })
+vim.keymap.set("n", "<leader>tp", ":tabprevious<CR>", { desc = "Previous tab" })
+vim.keymap.set("n", "<leader>tc", ":tabnew<CR>", { desc = "Create tab" })
+vim.keymap.set("n", "<leader>tx", ":tabclose<CR>", { desc = "Close tab" })
 
 -- New keymaps for tab positions
-vim.keymap.set('n', '<leader>t1', '1gt', { desc = 'Go to tab 1' })
-vim.keymap.set('n', '<leader>t2', '2gt', { desc = 'Go to tab 2' })
-vim.keymap.set('n', '<leader>t3', '3gt', { desc = 'Go to tab 3' })
-vim.keymap.set('n', '<leader>t4', '4gt', { desc = 'Go to tab 4' })
-vim.keymap.set('n', '<leader>t5', '5gt', { desc = 'Go to tab 5' })
-vim.keymap.set('n', '<leader>t0', ':tablast<CR>', { desc = 'Go to last tab' })
+vim.keymap.set("n", "<leader>t1", "1gt", { desc = "Go to tab 1" })
+vim.keymap.set("n", "<leader>t2", "2gt", { desc = "Go to tab 2" })
+vim.keymap.set("n", "<leader>t3", "3gt", { desc = "Go to tab 3" })
+vim.keymap.set("n", "<leader>t4", "4gt", { desc = "Go to tab 4" })
+vim.keymap.set("n", "<leader>t5", "5gt", { desc = "Go to tab 5" })
+vim.keymap.set("n", "<leader>t0", ":tablast<CR>", { desc = "Go to last tab" })
 
 -- Search behavior
 vim.opt.ignorecase = true

--- a/nvim-minimal/lua/options.lua
+++ b/nvim-minimal/lua/options.lua
@@ -37,6 +37,9 @@ vim.keymap.set('n', '<leader>t0', ':tablast<CR>', { desc = 'Go to last tab' })
 vim.opt.ignorecase = true
 vim.opt.smartcase = true
 
+-- Completion menu (native LSP autotrigger)
+vim.opt.completeopt = "menuone,noselect"
+
 -- Indentation and formatting
 vim.opt.expandtab = true
 vim.opt.tabstop = 4

--- a/nvim-minimal/lua/plugins.lua
+++ b/nvim-minimal/lua/plugins.lua
@@ -21,7 +21,11 @@ vim.cmd("colorscheme catppuccin-frappe")
 -- Treesitter (parsers installed via nvim-treesitter main branch; highlighting via core)
 local ts_parsers = { "go", "python", "lua", "markdown", "markdown_inline" }
 local ts_filetypes = { "go", "python", "lua", "markdown" }
-require("nvim-treesitter").install(ts_parsers)
+if vim.fn.executable("tree-sitter") == 1 and vim.fn.executable("git") == 1 then
+    require("nvim-treesitter").install(ts_parsers)
+else
+    vim.notify("nvim-treesitter: skipping parser install (need `tree-sitter` and `git`)", vim.log.levels.WARN)
+end
 vim.api.nvim_create_autocmd("FileType", {
     pattern = ts_filetypes,
     callback = function(args)

--- a/nvim-minimal/lua/plugins.lua
+++ b/nvim-minimal/lua/plugins.lua
@@ -1,0 +1,41 @@
+vim.pack.add({
+    { src = "https://github.com/catppuccin/nvim",                       name = "catppuccin" },
+    { src = "https://github.com/nvim-treesitter/nvim-treesitter",       version = "main" },
+    { src = "https://github.com/ibhagwan/fzf-lua" },
+})
+
+-- Colorscheme
+require("catppuccin").setup({
+    color_overrides = {
+        frappe = {
+            base = "#3a3a3a",
+            mantle = "#3a3a3a",
+            text = "#d2d2d2",
+            lavender = "#c6c6c6",
+        },
+    },
+    custom_highlights = { LineNr = { fg = "#7c7c7c" } },
+})
+vim.cmd("colorscheme catppuccin-frappe")
+
+-- Treesitter (parsers installed via nvim-treesitter main branch; highlighting via core)
+local ts_parsers = { "go", "python", "lua", "markdown", "markdown_inline" }
+local ts_filetypes = { "go", "python", "lua", "markdown" }
+require("nvim-treesitter").install(ts_parsers)
+vim.api.nvim_create_autocmd("FileType", {
+    pattern = ts_filetypes,
+    callback = function(args)
+        pcall(vim.treesitter.start, args.buf)
+        vim.bo[args.buf].indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
+    end,
+})
+
+-- fzf-lua
+local fzf = require("fzf-lua")
+fzf.setup({})
+vim.keymap.set("n", "<leader>ff", fzf.files, { desc = "Find files" })
+vim.keymap.set("n", "<leader>fg", fzf.live_grep, { desc = "Live grep" })
+vim.keymap.set("n", "<leader>fb", fzf.buffers, { desc = "Buffers" })
+vim.keymap.set("n", "<leader>fh", fzf.help_tags, { desc = "Help tags" })
+vim.keymap.set("n", "<leader>fd", fzf.diagnostics_document, { desc = "Diagnostics" })
+vim.keymap.set("n", "<leader>fs", fzf.grep_cword, { desc = "Grep word under cursor" })


### PR DESCRIPTION
## Summary
- New `nvim-minimal/` config: a dependency-light alternative to the main nvim setup, leaning on built-in Neovim features (`vim.pack`, `vim.lsp.config`, native LSP completion, `LspAttach`) instead of plugin managers and wrappers.
- Plugins: catppuccin (custom dark overrides), nvim-treesitter (main branch), fzf-lua. Avoids plenary/telescope ahead of plenary's archival.
- LSP: gopls + pyright, configured via `vim.lsp.config` with keymaps and native autocompletion wired up in `LspAttach`. No format-on-save.
